### PR TITLE
Fix V611

### DIFF
--- a/SDK/Utils/GradientRender.cpp
+++ b/SDK/Utils/GradientRender.cpp
@@ -25,7 +25,7 @@ CGradientRender::CGradientRender()
 CGradientRender::~CGradientRender()
 {
 	if ( m_Data != NULL )
-		delete m_Data;
+		delete [] m_Data;
 }
 
 void CGradientRender::DrawGradient( HDC hDC, RECT& rect, COLORREF startColor, COLORREF endColor, GradientType gradientType, TransformationType transformationType)
@@ -136,7 +136,7 @@ void CGradientRender::DrawGradient( HDC hDC, RECT& rect, COLORREF startColor, CO
 	SelectObject( hMemDC, hOldBitmap );
 	DeleteDC(hMemDC);
 	DeleteObject(hBitmap);
-	delete m_Data;
+	delete [] m_Data;
 	m_Data = NULL;
 }
 
@@ -221,7 +221,7 @@ void CGradientRender::ApplyTransformation(int width, int height, TransformationT
 	}
 
 	memcpy( m_Data, newBuffer, size );
-	delete newBuffer;
+	delete [] newBuffer;
 }
 #ifdef __WTLBUILDER__
 void CGradientRender::AddProperty(LPCTSTR Name,CProperties & objprop)

--- a/SDK/Utils/Ini.cpp
+++ b/SDK/Utils/Ini.cpp
@@ -842,9 +842,9 @@ DWORD CIni::__StringSplit(LPCTSTR lpString, LPTSTR lpBuffer, DWORD dwBufSize, LP
         lpTarget[COPY_LEN] = _T('\0');
     }
 
-    delete [] pszSeg;
+    free(pszSeg);
     lpBuffer[dwCopied] = _T('\0');
-    delete [] pszDel;
+    free(pszDel);
     return dwCopied;
 }
 
@@ -1056,7 +1056,7 @@ BOOL CIni::__TrimString(LPTSTR lpString)
     {
         LPTSTR psz = _tcsdup(p);
         _tcscpy(lpString, psz);
-        delete [] psz;
+        free(psz);
     }
 
     return bTrimmed;


### PR DESCRIPTION
V611 The memory was allocated using 'new T[]' operator but was released using the 'delete' operator. Consider inspecting this code. It's probably better to use 'delete [] newBuffer;'. gradientrender.cpp 224
V611 The memory was allocated using 'malloc/realloc' function but was released using the 'delete' operator. Consider inspecting operation logics behind the 'pszSeg' variable. ini.cpp 845
V611 The memory was allocated using 'malloc/realloc' function but was released using the 'delete' operator. Consider inspecting operation logics behind the 'pszDel' variable. ini.cpp 847
V611 The memory was allocated using 'malloc/realloc' function but was released using the 'delete' operator. Consider inspecting operation logics behind the 'psz' variable. ini.cpp 1059